### PR TITLE
Add coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
   https://github.com/yonatankarp/pitest-summary/actions/workflows/ci.yml/badge.svg
 [ci-state]:
   https://github.com/yonatankarp/pitest-summary/actions/workflows/ci.yml
+[coverage-badge]: badges/coverage.svg
 
 [![Linters][linter-badge]][linter-state] [![CI][ci-badge]][ci-state]
+![coverage.svg][coverage-badge]
 
 This action is a simple action that summarizes the results of a PITest run. It
 parses the XML output of the PITest run and prints a summary of the results to


### PR DESCRIPTION
This commit appends the auto-generated coverage badge to the README file, so it is clear how much of the code is actually covered by tests.

This should give a sense of trust to the users that this action acutally tests the business logic behind the action, and for the contributors that dependencies could be updated automatically be dependabot without breaking the action.