### PR TITLE
Fix example workflow

### DIFF
--- a/.github/workflows/example-workflow.yml
+++ b/.github/workflows/example-workflow.yml
@@ -7,6 +7,10 @@ on:
         description: 'The path to the file to be analyzed'
         required: true
         default: './mutations.xml'
+      display-only-survived:
+        description: 'Whether to display only survived mutations'
+        required: false
+        default: 'false'
 
 permissions:
   actions: read
@@ -18,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
       - name: Summarize Mutations
         id: test-action-all-mutations
         # Change @main to a specific commit SHA or version tag, e.g.:
@@ -26,3 +34,5 @@ jobs:
         uses: yonatankarp/pitest-summary@add-action
         with:
           file-path: ${{ github.event.inputs.file-path }}
+          display-only-survived:
+            ${{ github.event.inputs.display-only-survived }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This pipeline will run the PITest mutation tests on a schedule (every day at
 midnight) and summarize the results in the log.
 
 For example, workflow runs, check out the
-[Actions tab](https://github.com/yonatankarp/pitest-summary/actions)! 🚀
+[Actions tab](https://github.com/yonatankarp/pitest-summary/actions/workflows/example-workflow.yml)
+for an example of a workflow executions! 🚀
 
 ## Inputs
 


### PR DESCRIPTION
This PR fixes the example workflow by adding the `checkout` action to ensure that the `mutation.xml` file is actually available during the execution of the action.

In real execution, it would most probably not be committed but generated by PIT, however for the sake of simplicity this repo uses a static XML