### PR TITLE
Refactor calls to leverage the async-await paradigm

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,12 +1,31 @@
 /**
  * Unit tests for the action's main functionality, src/main.js
  */
-const core = require('@actions/core')
-const github = require('@actions/github')
-const main = require('../src/main')
 
-describe('action', () => {
-  test('should set failed if file-path input is missing', async () => {})
+const fs = require('node:fs/promises')
+// const xml2js = require('xml2js')
+const core = require('@actions/core')
+
+jest.mock('node:fs/promises')
+// jest.mock('xml2js')
+jest.mock('@actions/core')
+
+describe('/src/main.js', () => {
+  test('should set failed if file-path input is missing', async () => {
+    // arrange
+    const mockReadErrorMessage = 'File not found'
+    core.getInput.mockReturnValueOnce('stam_file.xml')
+    core.getInput.mockReturnValueOnce('false')
+    fs.readFile.mockRejectedValue(new Error(mockReadErrorMessage))
+
+    // act
+    await require('../src/main').run()
+
+    // assert
+    await expect(core.setFailed).toHaveBeenCalledWith(
+      `Error reading XML file: ${mockReadErrorMessage}`
+    )
+  })
 
   test('should handle file read error', async () => {})
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,15 @@
-const fs = require('fs')
+const fs = require('node:fs/promises')
 const xml2js = require('xml2js')
 const core = require('@actions/core')
+
+let reportContent = `
+# Mutation Test Summary
+        
+## Overview
+
+This report provides an overview of mutation testing results, grouped by file. Each entry details a mutation attempt, its detection status, and specific mutation description.
+
+`.trimStart() // Removes the first new line, before "# Mutation Test Summary"
 
 async function run() {
   // Read inputs of the action
@@ -9,18 +18,12 @@ async function run() {
     core.getInput('display-only-survived', { required: false }) === 'true'
 
   const parser = new xml2js.Parser()
-  fs.readFile(filePath, (err, data) => {
-    if (err) {
-      core.setFailed(`Error reading XML file: ${err.message}`)
-      return
-    }
-
-    parser.parseString(data, (parseError, result) => {
-      if (parseError) {
-        core.setFailed(`Error parsing XML: ${parseError.message}`)
-        return
-      }
-
+  let data = null
+  try {
+    data = await fs.readFile(filePath)
+    let result = null
+    try {
+      result = await parser.parseStringPromise(data)
       const mutationsResult = result.mutations.mutation
       const fileGroups = mutationsResult.reduce((acc, mutation) => {
         const file = mutation.sourceFile[0]
@@ -39,14 +42,6 @@ async function run() {
         return acc
       }, {})
 
-      let reportContent = `# Mutation Test Summary
-        
-## Overview
-
-This report provides an overview of mutation testing results, grouped by file. Each entry details a mutation attempt, its detection status, and specific mutation description.
-
-`
-
       for (const [file, mutations] of Object.entries(fileGroups)) {
         reportContent += `### Mutations in ${file}\n`
         for (const mutation of mutations) {
@@ -57,8 +52,12 @@ This report provides an overview of mutation testing results, grouped by file. E
 
       // Write directly to the GitHub Step Summary using @actions/core
       core.summary.addRaw(reportContent).write()
-    })
-  })
+    } catch (parseError) {
+      core.setFailed(`Error parsing XML: ${parseError.message}`)
+    }
+  } catch (readError) {
+    core.setFailed(`Error reading XML file: ${readError.message}`)
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
This PR by @y0n1 changes the implementation suggested by ChatGPT to leverage the async-await paradigm in JS instead of the previous implementation.

Not only that the code is cleaner now and easier to understand, but writing the tests become much easier as well 🎉 